### PR TITLE
Feature/exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ gulp.task('watch', function () {
 
 **bless(options)**. The (optional) `options` argument is passed on to [bless.js](https://github.com/paulyoung/bless.js). You can also include a `log` option to control whether Gulp should log output which defaults to `false` (this isn't passed to `bless.js`).
 
+An exclude option is also not passed to bless. It's a glob that, when matched, just passes files through unchanged.
+
 Bless' options are listed here: [paulyoung/bless.js/blob/master/bin/blessc#L10](https://github.com/paulyoung/bless.js/blob/master/bin/blessc#L10).
 For example, if you didn't want the first CSS chunk / "blessed" file to `@import` the others, then you'd do this:
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var through = require('through2');
 var path = require('path');
 var bless = require('bless');
 var gutil = require('gulp-util');
+var minimatch = require('minimatch');
 var merge = require('merge');
 var File = gutil.File;
 var PluginError = gutil.PluginError;
@@ -25,13 +26,15 @@ module.exports = function(options){
         if (file.isStream()) return cb(new PluginError(pluginName,  'Streaming not supported'));
 
         var stream = this;
+        var skip = options.exclude && minimatch(file.path, options.exclude);
 
-        if (file.contents && file.contents.toString()) {
+        if (!skip && file.contents && file.contents.toString()) {
             var fileName = path.basename(file.path);
             var outputFilePath = path.resolve(path.dirname(file.path), fileName);
             var contents = file.contents.toString('utf8');
             var blessOpts = merge(true, options);
-            if(typeof blessOpts.log !== 'undefined') delete blessOpts.log
+            if(typeof blessOpts.log !== 'undefined') delete blessOpts.log;
+            if(typeof blessOpts.exclude !== 'undefined') delete blessOpts.exclude;
 
             new (bless.Parser)({
                 output: outputFilePath,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bless": "~3.0.3",
     "gulp-util": "*",
     "through2": "~0.5.1",
+    "minimatch": "~2.0.4",
     "merge": "~1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-bless",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "homepage": "http://github.com/adam-lynch/gulp-bless",
   "description": "CSS post-processor which splits CSS files suitably for Internet Explorer < 10. Bless + Gulp = gulp-bless.",
   "main": "./index.js",


### PR DESCRIPTION
Having an exclude option makes it easy to leave out some files from being blessed without doing stream magic. Adding it definitely reduced complexity for our stream handling in CSS builds.